### PR TITLE
Test for RFP

### DIFF
--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -895,11 +895,11 @@ def test_rfp():
     tfttp, tpttf = get_lapack_funcs(('tfttp', 'tpttf'))
 
     even_size = 6
-    even_rfp_shape = (3, 7)
-    even_rfp_shape_trans = (7, 3)
+    even_rfp_shape = (7, 3)
+    even_rfp_shape_trans = (3, 7)
     odd_size = 5
-    odd_rfp_shape = (3, 5)
-    odd_rfp_shape_trans = (5, 3)
+    odd_rfp_shape = (5, 3)
+    odd_rfp_shape_trans = (3, 5)
 
     # Upper
     # -----
@@ -913,7 +913,7 @@ def test_rfp():
                    1005, 1015, 1025, 1035, 1045, 1055])
     Arf, info = tpttf(even_size, Ap)  # Default: uplo = 'U'
     ArfT, info = tpttf(even_size, Ap, transr='T')
-    assert (Arf.reshape(even_rfp_shape).T == np.array(
+    assert (Arf.reshape(even_rfp_shape, order='F') == np.array(
         [[1003, 1004, 1005],
          [1013, 1014, 1015],
          [1023, 1024, 1025],
@@ -921,8 +921,8 @@ def test_rfp():
          [1000, 1044, 1045],
          [1001, 1011, 1055],
          [1002, 1012, 1022]])).all()
-    assert (Arf.reshape(even_rfp_shape).T ==
-            ArfT.reshape(even_rfp_shape_trans)).all()
+    assert (Arf.reshape(even_rfp_shape, order='F').T ==
+            ArfT.reshape(even_rfp_shape_trans, order='F')).all()
     Ap1, info = tfttp(even_size, Arf)
     assert (Ap1 == Ap).all()
     Ap1T, info = tfttp(even_size, ArfT, transr='T')
@@ -936,14 +936,14 @@ def test_rfp():
                    1004, 1014, 1024, 1034, 1044])
     Arf, info = tpttf(odd_size, Ap)  # Default: uplo = 'U'
     ArfT, info = tpttf(odd_size, Ap, transr='T')
-    assert (Arf.reshape(odd_rfp_shape).T == np.array(
+    assert (Arf.reshape(odd_rfp_shape, order='F') == np.array(
         [[1002, 1003, 1004],
          [1012, 1013, 1014],
          [1022, 1023, 1024],
          [1000, 1033, 1034],
          [1001, 1011, 1044]])).all()
-    assert (Arf.reshape(odd_rfp_shape).T ==
-            ArfT.reshape(odd_rfp_shape_trans)).all()
+    assert (Arf.reshape(odd_rfp_shape, order='F').T ==
+            ArfT.reshape(odd_rfp_shape_trans, order='F')).all()
     Ap1, info = tfttp(odd_size, Arf)
     assert (Ap1 == Ap).all()
     Ap1T, info = tfttp(odd_size, ArfT, transr='T')
@@ -961,7 +961,7 @@ def test_rfp():
                                                  1055])
     Arf, info = tpttf(even_size, Ap, uplo='L')
     ArfT, info = tpttf(even_size, Ap, uplo='L', transr='T')
-    assert (Arf.reshape(even_rfp_shape).T == np.array(
+    assert (Arf.reshape(even_rfp_shape, order='F') == np.array(
         [[1033, 1043, 1053],
          [1000, 1044, 1054],
          [1010, 1011, 1055],
@@ -969,8 +969,8 @@ def test_rfp():
          [1030, 1031, 1032],
          [1040, 1041, 1042],
          [1050, 1051, 1052]])).all()
-    assert (Arf.reshape(even_rfp_shape).T ==
-            ArfT.reshape(even_rfp_shape_trans)).all()
+    assert (Arf.reshape(even_rfp_shape, order='F').T ==
+            ArfT.reshape(even_rfp_shape_trans, order='F')).all()
     Ap1, info = tfttp(even_size, Arf, uplo='L')
     assert (Ap1 == Ap).all()
     Ap1T, info = tfttp(even_size, ArfT, uplo='L', transr='T')
@@ -984,14 +984,14 @@ def test_rfp():
                                            1044])
     Arf, info = tpttf(odd_size, Ap, uplo='L')
     ArfT, info = tpttf(odd_size, Ap, uplo='L', transr='T')
-    assert (Arf.reshape(odd_rfp_shape).T == np.array(
+    assert (Arf.reshape(odd_rfp_shape, order='F') == np.array(
         [[1000, 1033, 1043],
          [1010, 1011, 1044],
          [1020, 1021, 1022],
          [1030, 1031, 1032],
          [1040, 1041, 1042]])).all()
-    assert (Arf.reshape(odd_rfp_shape).T ==
-            ArfT.reshape(odd_rfp_shape_trans)).all()
+    assert (Arf.reshape(odd_rfp_shape, order='F').T ==
+            ArfT.reshape(odd_rfp_shape_trans, order='F')).all()
     Ap1, info = tfttp(odd_size, Arf, uplo='L')
     assert (Ap1 == Ap).all()
     Ap1T, info = tfttp(odd_size, ArfT, uplo='L', transr='T')

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -887,85 +887,115 @@ def test_hegst():
         assert_(info == 0)
         assert_allclose(eig, eig_gvd, rtol=1e-4)
 
+
 def test_rfp():
     """ Test LAPACK routines operating on the Rectangular Full Packed (RFP)
         format
     """
     tfttp, tpttf = get_lapack_funcs(('tfttp', 'tpttf'))
 
+    even_size = 6
+    even_rfp_shape = (3, 7)
+    even_rfp_shape_trans = (7, 3)
+    odd_size = 5
+    odd_rfp_shape = (3, 5)
+    odd_rfp_shape_trans = (5, 3)
+
     # Upper
+    # -----
 
-    ## Even size
+    # Even size
     Ap = np.array([1000,
-                      1001, 1011,
-                      1002, 1012, 1022,
-                      1003, 1013, 1023, 1033,
-                      1004, 1014, 1024, 1034, 1044,
-                      1005, 1015, 1025, 1035, 1045, 1055])
-    Arf, info = tpttf(6, Ap) # Default: uplo = 'U'
-    assert (Arf.reshape((3,7)).T == np.array(
-    [[1003, 1004, 1005],
-     [1013, 1014, 1015],
-     [1023, 1024, 1025],
-     [1033, 1034, 1035],
-     [1000, 1044, 1045],
-     [1001, 1011, 1055],
-     [1002, 1012, 1022]])).all()
-    Ap1, info = tfttp(6, Arf)
+                   1001, 1011,
+                   1002, 1012, 1022,
+                   1003, 1013, 1023, 1033,
+                   1004, 1014, 1024, 1034, 1044,
+                   1005, 1015, 1025, 1035, 1045, 1055])
+    Arf, info = tpttf(even_size, Ap)  # Default: uplo = 'U'
+    ArfT, info = tpttf(even_size, Ap, transr='T')
+    assert (Arf.reshape(even_rfp_shape).T == np.array(
+        [[1003, 1004, 1005],
+         [1013, 1014, 1015],
+         [1023, 1024, 1025],
+         [1033, 1034, 1035],
+         [1000, 1044, 1045],
+         [1001, 1011, 1055],
+         [1002, 1012, 1022]])).all()
+    assert (Arf.reshape(even_rfp_shape).T ==
+            ArfT.reshape(even_rfp_shape_trans)).all()
+    Ap1, info = tfttp(even_size, Arf)
     assert (Ap1 == Ap).all()
+    Ap1T, info = tfttp(even_size, ArfT, transr='T')
+    assert (Ap1T == Ap).all()
 
-    ## Odd size
+    # Odd size
     Ap = np.array([1000,
-                      1001, 1011,
-                      1002, 1012, 1022,
-                      1003, 1013, 1023, 1033,
-                      1004, 1014, 1024, 1034, 1044])
-    Arf, info = tpttf(5, Ap) # Default: uplo = 'U'
-    assert (Arf.reshape((3,5)).T == np.array(
-    [[1002, 1003, 1004],
-     [1012, 1013, 1014],
-     [1022, 1023, 1024],
-     [1000, 1033, 1034],
-     [1001, 1011, 1044]])).all()
-    Ap1, info = tfttp(5, Arf)
+                   1001, 1011,
+                   1002, 1012, 1022,
+                   1003, 1013, 1023, 1033,
+                   1004, 1014, 1024, 1034, 1044])
+    Arf, info = tpttf(odd_size, Ap)  # Default: uplo = 'U'
+    ArfT, info = tpttf(odd_size, Ap, transr='T')
+    assert (Arf.reshape(odd_rfp_shape).T == np.array(
+        [[1002, 1003, 1004],
+         [1012, 1013, 1014],
+         [1022, 1023, 1024],
+         [1000, 1033, 1034],
+         [1001, 1011, 1044]])).all()
+    assert (Arf.reshape(odd_rfp_shape).T ==
+            ArfT.reshape(odd_rfp_shape_trans)).all()
+    Ap1, info = tfttp(odd_size, Arf)
     assert (Ap1 == Ap).all()
+    Ap1T, info = tfttp(odd_size, ArfT, transr='T')
+    assert (Ap1T == Ap).all()
 
     # Lower
+    # -----
 
-    ## Even size
+    # Even size
     Ap = np.array([1000, 1010, 1020, 1030, 1040, 1050,
-                            1011, 1021, 1031, 1041, 1051,
-                                  1022, 1032, 1042, 1052,
-                                        1033, 1043, 1053,
-                                              1044, 1054,
-                                                    1055])
-    Arf, info = tpttf(6, Ap, uplo='L')
-    assert (Arf.reshape((3,7)).T == np.array(
-    [[1033, 1043, 1053],
-     [1000, 1044, 1054],
-     [1010, 1011, 1055],
-     [1020, 1021, 1022],
-     [1030, 1031, 1032],
-     [1040, 1041, 1042],
-     [1050, 1051, 1052]])).all()
-    Ap1, info = tfttp(6, Arf, uplo='L')
+                         1011, 1021, 1031, 1041, 1051,
+                               1022, 1032, 1042, 1052,
+                                     1033, 1043, 1053,
+                                           1044, 1054,
+                                                 1055])
+    Arf, info = tpttf(even_size, Ap, uplo='L')
+    ArfT, info = tpttf(even_size, Ap, uplo='L', transr='T')
+    assert (Arf.reshape(even_rfp_shape).T == np.array(
+        [[1033, 1043, 1053],
+         [1000, 1044, 1054],
+         [1010, 1011, 1055],
+         [1020, 1021, 1022],
+         [1030, 1031, 1032],
+         [1040, 1041, 1042],
+         [1050, 1051, 1052]])).all()
+    assert (Arf.reshape(even_rfp_shape).T ==
+            ArfT.reshape(even_rfp_shape_trans)).all()
+    Ap1, info = tfttp(even_size, Arf, uplo='L')
     assert (Ap1 == Ap).all()
+    Ap1T, info = tfttp(even_size, ArfT, uplo='L', transr='T')
+    assert (Ap1T == Ap).all()
 
-    ## Odd size
+    # Odd size
     Ap = np.array([1000, 1010, 1020, 1030, 1040,
-                            1011, 1021, 1031, 1041,
-                                  1022, 1032, 1042,
-                                        1033, 1043,
-                                              1044])
-    Arf, info = tpttf(5, Ap, uplo='L')
-    assert (Arf.reshape((3,5)).T == np.array(
-    [[1000, 1033, 1043],
-     [1010, 1011, 1044],
-     [1020, 1021, 1022],
-     [1030, 1031, 1032],
-     [1040, 1041, 1042]])).all()
-    Ap1, info = tfttp(5, Arf, uplo='L')
+                         1011, 1021, 1031, 1041,
+                               1022, 1032, 1042,
+                                     1033, 1043,
+                                           1044])
+    Arf, info = tpttf(odd_size, Ap, uplo='L')
+    ArfT, info = tpttf(odd_size, Ap, uplo='L', transr='T')
+    assert (Arf.reshape(odd_rfp_shape).T == np.array(
+        [[1000, 1033, 1043],
+         [1010, 1011, 1044],
+         [1020, 1021, 1022],
+         [1030, 1031, 1032],
+         [1040, 1041, 1042]])).all()
+    assert (Arf.reshape(odd_rfp_shape).T ==
+            ArfT.reshape(odd_rfp_shape_trans)).all()
+    Ap1, info = tfttp(odd_size, Arf, uplo='L')
     assert (Ap1 == Ap).all()
+    Ap1T, info = tfttp(odd_size, ArfT, uplo='L', transr='T')
+    assert (Ap1T == Ap).all()
 
 
 def test_tzrzf():

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -887,6 +887,86 @@ def test_hegst():
         assert_(info == 0)
         assert_allclose(eig, eig_gvd, rtol=1e-4)
 
+def test_rfp():
+    """ Test LAPACK routines operating on the Rectangular Full Packed (RFP)
+        format
+    """
+    tfttp, tpttf = get_lapack_funcs(('tfttp', 'tpttf'))
+
+    # Upper
+
+    ## Even size
+    Ap = np.array([1000,
+                      1001, 1011,
+                      1002, 1012, 1022,
+                      1003, 1013, 1023, 1033,
+                      1004, 1014, 1024, 1034, 1044,
+                      1005, 1015, 1025, 1035, 1045, 1055])
+    Arf, info = tpttf(6, Ap) # Default: uplo = 'U'
+    assert (Arf.reshape((3,7)).T == np.array(
+    [[1003, 1004, 1005],
+     [1013, 1014, 1015],
+     [1023, 1024, 1025],
+     [1033, 1034, 1035],
+     [1000, 1044, 1045],
+     [1001, 1011, 1055],
+     [1002, 1012, 1022]])).all()
+    Ap1, info = tfttp(6, Arf)
+    assert (Ap1 == Ap).all()
+
+    ## Odd size
+    Ap = np.array([1000,
+                      1001, 1011,
+                      1002, 1012, 1022,
+                      1003, 1013, 1023, 1033,
+                      1004, 1014, 1024, 1034, 1044])
+    Arf, info = tpttf(5, Ap) # Default: uplo = 'U'
+    assert (Arf.reshape((3,5)).T == np.array(
+    [[1002, 1003, 1004],
+     [1012, 1013, 1014],
+     [1022, 1023, 1024],
+     [1000, 1033, 1034],
+     [1001, 1011, 1044]])).all()
+    Ap1, info = tfttp(5, Arf)
+    assert (Ap1 == Ap).all()
+
+    # Lower
+
+    ## Even size
+    Ap = np.array([1000, 1010, 1020, 1030, 1040, 1050,
+                            1011, 1021, 1031, 1041, 1051,
+                                  1022, 1032, 1042, 1052,
+                                        1033, 1043, 1053,
+                                              1044, 1054,
+                                                    1055])
+    Arf, info = tpttf(6, Ap, uplo='L')
+    assert (Arf.reshape((3,7)).T == np.array(
+    [[1033, 1043, 1053],
+     [1000, 1044, 1054],
+     [1010, 1011, 1055],
+     [1020, 1021, 1022],
+     [1030, 1031, 1032],
+     [1040, 1041, 1042],
+     [1050, 1051, 1052]])).all()
+    Ap1, info = tfttp(6, Arf, uplo='L')
+    assert (Ap1 == Ap).all()
+
+    ## Odd size
+    Ap = np.array([1000, 1010, 1020, 1030, 1040,
+                            1011, 1021, 1031, 1041,
+                                  1022, 1032, 1042,
+                                        1033, 1043,
+                                              1044])
+    Arf, info = tpttf(5, Ap, uplo='L')
+    assert (Arf.reshape((3,5)).T == np.array(
+    [[1000, 1033, 1043],
+     [1010, 1011, 1044],
+     [1020, 1021, 1022],
+     [1030, 1031, 1032],
+     [1040, 1041, 1042]])).all()
+    Ap1, info = tfttp(5, Arf, uplo='L')
+    assert (Ap1 == Ap).all()
+
 
 def test_tzrzf():
     """


### PR DESCRIPTION
I suggest the following strategy for testing RFP. 

1. test the conversion routines between standard packed, standard full format and RFP format. I started that in the first commit #0f43a80 using the examples in LAPACK source code

2. test the linear algebra operations on RFP as LAPACK does it, by simply comparing to the corresponding operations on full format. For example to test the rank-k update, start from full format, then apply TRTTF, then SFRK, then TFTTR, and compare that to applying SYRK directly to the starting matrix.

Question: how much coverage do you wish to have?