### PR TITLE
ENH:MAINT Add wrappers for cython cdflib functions

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -14455,12 +14455,174 @@ add_newdoc("ndtri_exp",
     9.262340089798409
     """)
 
+add_newdoc("bdtrik_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("bdtrin_cython",
+    """
+    Private function; do not use.
+    """)
+
 add_newdoc("btdtria_cython",
     """
     Private function; do not use.
     """)
 
 add_newdoc("btdtrib_cython",
+    """
+    Private function; do not use.
+    """)
+
+
+add_newdoc("btdtrik_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("btdtrin_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("chdtriv_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("chndtr_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("chndtridf_cython",
+    """
+    Private function; do not use.
+    """)
+
+
+add_newdoc("chndtrinc_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("chndtrix_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("fdtridfd_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("gdtria_cython",
+    """
+    Private function; do not use.
+    """)
+
+
+add_newdoc("gdtrib_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("gdtrix_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("nbdtrik_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("nbdtrin_cython",
+    """
+    Private function; do not use.
+    """)
+
+
+add_newdoc("ncfdtr_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("ncfdtri_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("ncfdtridfd_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("ncfdtridfn_cython",
+    """
+    Private function; do not use.
+    """)
+
+
+add_newdoc("ncfdtrinc_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("nctdtr_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("nctdtridf_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("nctdtrinc_cython",
+    """
+    Private function; do not use.
+    """)
+
+
+add_newdoc("nctdtrit_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("nrdtrimn_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("nrdtrisd_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("pdtrik_cython",
+    """
+    Private function; do not use.
+    """)
+
+
+add_newdoc("stdtr_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("stdtridf_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("stdtrit_cython",
+    """
+    Private function; do not use.
+    """)
+
+add_newdoc("tklmbda_cephes",
     """
     Private function; do not use.
     """)

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -14454,3 +14454,8 @@ add_newdoc("ndtri_exp",
     >>> sc.ndtri_exp(-1e-20)
     9.262340089798409
     """)
+
+add_newdoc("btdtria_cython",
+    """
+    Private function; do not use.
+    """)

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -14459,3 +14459,8 @@ add_newdoc("btdtria_cython",
     """
     Private function; do not use.
     """)
+
+add_newdoc("btdtrib_cython",
+    """
+    Private function; do not use.
+    """)

--- a/scipy/special/_cdflib.pxd
+++ b/scipy/special/_cdflib.pxd
@@ -31,6 +31,14 @@ cdef (double, double, int, double) cdff_which1(double f, double dfn, double dfd)
 cdef (double, int, double) cdff_which2(double p, double q, double dfn, double dfd) noexcept nogil
 cdef (double, int, double) cdff_which3(double p, double q, double f, double dfd) noexcept nogil
 cdef (double, int, double) cdff_which4(double p, double q, double f, double dfn) noexcept nogil
+cdef (double, double, int, double) cdffnc_which1(double f, double dfn, double dfd, double phonc) nogil
+cdef (double, int, double) cdffnc_which2(double p, double q, double dfn, double dfd, double phonc) nogil
+cdef (double, int, double) cdffnc_which3(double p, double q, double f, double dfd, double phonc) nogil
+cdef (double, int, double) cdffnc_which4(double p, double q, double f, double dfn, double phonc) nogil
+cdef (double, double, int, double) cdfgam_which1(double x, double shape, double scale) nogil
+cdef (double, int, double) cdfgam_which2(double p, double q, double shape, double scale) nogil
+cdef (double, int, double) cdfgam_which3(double p, double q, double x, double scale) nogil
+cdef (double, int, double) cdfgam_which4(double p, double q, double x, double shape) nogil
 cdef (double, double, int, double) cdfnbn_which1(double s, double xn, double pr, double ompr) noexcept nogil
 cdef (double, int, double) cdfnbn_which2(double p, double q, double xn, double pr, double ompr) noexcept nogil
 cdef (double, int, double) cdfnbn_which3(double p, double q, double s, double pr, double ompr) noexcept nogil

--- a/scipy/special/_cdflib.pxd
+++ b/scipy/special/_cdflib.pxd
@@ -35,6 +35,7 @@ cdef (double, double, int, double) cdffnc_which1(double f, double dfn, double df
 cdef (double, int, double) cdffnc_which2(double p, double q, double dfn, double dfd, double phonc) noexcept nogil
 cdef (double, int, double) cdffnc_which3(double p, double q, double f, double dfd, double phonc) noexcept nogil
 cdef (double, int, double) cdffnc_which4(double p, double q, double f, double dfn, double phonc) noexcept nogil
+cdef (double, int, double) cdffnc_which5(double p, double q, double f, double dfn, double dfd) noexcept nogil
 cdef (double, double, int, double) cdfgam_which1(double x, double shape, double scale) noexcept nogil
 cdef (double, int, double) cdfgam_which2(double p, double q, double shape, double scale) noexcept nogil
 cdef (double, int, double) cdfgam_which3(double p, double q, double x, double scale) noexcept nogil

--- a/scipy/special/_cdflib.pxd
+++ b/scipy/special/_cdflib.pxd
@@ -31,14 +31,14 @@ cdef (double, double, int, double) cdff_which1(double f, double dfn, double dfd)
 cdef (double, int, double) cdff_which2(double p, double q, double dfn, double dfd) noexcept nogil
 cdef (double, int, double) cdff_which3(double p, double q, double f, double dfd) noexcept nogil
 cdef (double, int, double) cdff_which4(double p, double q, double f, double dfn) noexcept nogil
-cdef (double, double, int, double) cdffnc_which1(double f, double dfn, double dfd, double phonc) nogil
-cdef (double, int, double) cdffnc_which2(double p, double q, double dfn, double dfd, double phonc) nogil
-cdef (double, int, double) cdffnc_which3(double p, double q, double f, double dfd, double phonc) nogil
-cdef (double, int, double) cdffnc_which4(double p, double q, double f, double dfn, double phonc) nogil
-cdef (double, double, int, double) cdfgam_which1(double x, double shape, double scale) nogil
-cdef (double, int, double) cdfgam_which2(double p, double q, double shape, double scale) nogil
-cdef (double, int, double) cdfgam_which3(double p, double q, double x, double scale) nogil
-cdef (double, int, double) cdfgam_which4(double p, double q, double x, double shape) nogil
+cdef (double, double, int, double) cdffnc_which1(double f, double dfn, double dfd, double phonc) noexcept nogil
+cdef (double, int, double) cdffnc_which2(double p, double q, double dfn, double dfd, double phonc) noexcept nogil
+cdef (double, int, double) cdffnc_which3(double p, double q, double f, double dfd, double phonc) noexcept nogil
+cdef (double, int, double) cdffnc_which4(double p, double q, double f, double dfn, double phonc) noexcept nogil
+cdef (double, double, int, double) cdfgam_which1(double x, double shape, double scale) noexcept nogil
+cdef (double, int, double) cdfgam_which2(double p, double q, double shape, double scale) noexcept nogil
+cdef (double, int, double) cdfgam_which3(double p, double q, double x, double scale) noexcept nogil
+cdef (double, int, double) cdfgam_which4(double p, double q, double x, double shape) noexcept nogil
 cdef (double, double, int, double) cdfnbn_which1(double s, double xn, double pr, double ompr) noexcept nogil
 cdef (double, int, double) cdfnbn_which2(double p, double q, double xn, double pr, double ompr) noexcept nogil
 cdef (double, int, double) cdfnbn_which3(double p, double q, double s, double pr, double ompr) noexcept nogil

--- a/scipy/special/_cdflib_wrappers.pxd
+++ b/scipy/special/_cdflib_wrappers.pxd
@@ -20,6 +20,19 @@ from ._cdflib cimport (
     cdfnbn_which3,
     cdffnc_which1,
     cdffnc_which2,
+    cdffnc_which3,
+    cdffnc_which4,
+    cdffnc_which5,
+    cdftnc_which1,
+    cdftnc_which2,
+    cdftnc_which3,
+    cdftnc_which4,
+    cdfnor_which3,
+    cdfnor_which4,
+    cdfpoi_which2,
+    cdft_which1,
+    cdft_which2,
+    cdft_which3,
 )
 
 
@@ -58,7 +71,6 @@ cdef inline double get_result(
     sf_error.error(name, sf_error.OTHER, "Unknown error.")
     return NAN
     
-
 
 cdef inline double btdtria(double p, double b, double x) noexcept nogil:
     cdef:
@@ -297,9 +309,212 @@ cdef inline double ncfdtri(double dfn, double dfd, double nc, double p) noexcept
 
     argnames[0] = "p"
     argnames[1] = "q"
-    argnames[1] = "dfn"
-    argnames[2] = "dfd"
-    argnames[3] = "nc"
+    argnames[2] = "dfn"
+    argnames[3] = "dfd"
+    argnames[4] = "nc"
 
     result, status, bound = cdffnc_which2(p, q, dfn, dfd, nc)
     return get_result("ncfdtri", argnames, result, status, bound, 1)
+
+
+cdef inline double ncfdtridfd(double dfn, double p, double nc, double f) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double result, bound
+        int status = 10
+        char *argnames[5]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "f"
+    argnames[3] = "dfn"
+    argnames[4] = "nc"
+
+    result, status, bound = cdffnc_which4(p, q, f, dfn, nc)
+    return get_result("ncfdtridfd", argnames, result, status, bound, 1)
+
+
+cdef inline double ncfdtridfn(double p, double dfd, double nc, double f) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double result, bound
+        int status = 10
+        char *argnames[5]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "f"
+    argnames[3] = "dfd"
+    argnames[4] = "nc"
+
+    result, status, bound = cdffnc_which3(p, q, f, dfd, nc)
+    return get_result("ncfdtridfn", argnames, result, status, bound, 1)
+
+
+cdef inline double ncfdtrinc(double dfn, double dfd, double p, double f) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double result, bound
+        int status = 10
+        char *argnames[5]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "f"
+    argnames[3] = "dfn"
+    argnames[4] = "dfd"
+
+    result, status, bound = cdffnc_which5(p, q, f, dfn, dfd)
+    return get_result("ncfdtrinc", argnames, result, status, bound, 1)
+
+
+cdef inline double nctdtr(double df, double nc, double t) noexcept nogil:
+    cdef:
+        double result, _, bound
+        int status = 10
+        char *argnames[3]
+
+    argnames[0] = "t"
+    argnames[1] = "df"
+    argnames[2] = "nc"
+
+    result, _, status, bound = cdftnc_which1(t, df, nc)
+    return get_result("nctdtr", argnames, result, status, bound, 1)
+
+
+cdef inline double nctdtridf(double p, double nc, double t) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double result, bound
+        int status = 10
+        char *argnames[4]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "t"
+    argnames[3] = "nc"
+
+    result, status, bound = cdftnc_which3(p, q, t, nc)
+    return get_result("nctdtridf", argnames, result, status, bound, 1)
+
+
+cdef inline double nctdtrinc(double df, double p, double t) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double result, bound
+        int status = 10
+        char *argnames[4]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "t"
+    argnames[3] = "df"
+
+    result, status, bound = cdftnc_which4(p, q, t, df)
+    return get_result("nctdtrinc", argnames, result, status, bound, 1)
+
+
+cdef inline double nctdtrit(double df, double nc, double p) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double result, bound
+        int status = 10
+        char *argnames[4]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "df"
+    argnames[3] = "nc"
+
+    result, status, bound = cdftnc_which2(p, q, df, nc)
+    return get_result("nctdtrit", argnames, result, status, bound, 1)
+
+
+cdef inline double nrdtrimn(double p, double std, double x) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double result, bound
+        int status = 10
+        char *argnames[4]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "x"
+    argnames[3] = "std"
+
+    result, status, bound = cdfnor_which3(p, q, x, std)
+    return get_result("nrdtrimn", argnames, result, status, bound, 1)
+
+
+cdef inline double nrdtrisd(double mn, double p, double x) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double result, bound
+        int status = 10
+        char *argnames[4]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "x"
+    argnames[3] = "mn"
+
+    result, status, bound = cdfnor_which4(p, q, x, mn)
+    return get_result("nrdtrisd", argnames, result, status, bound, 1)
+
+
+cdef inline double pdtrik(double p, double xlam) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double result, bound
+        int status = 10
+        char *argnames[3]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "xlam"
+
+    result, status, bound = cdfpoi_which2(p, q, xlam)
+    return get_result("pdtrik", argnames, result, status, bound, 1)
+
+
+cdef inline double stdtr(double t, double df) noexcept nogil:
+    cdef:
+        double result, _, bound
+        int status = 10
+        char *argnames[2]
+
+    argnames[0] = "t"
+    argnames[1] = "df"
+
+    result, _, status, bound = cdft_which1(t, df)
+    return get_result("stdtr", argnames, result, status, bound, 1)
+
+
+cdef inline double stdtridf(double p, double t) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double result, bound
+        int status = 10
+        char *argnames[3]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "t"
+
+    result, status, bound = cdft_which3(p, q, t)
+    return get_result("stdtridf", argnames, result, status, bound, 1)
+
+
+cdef inline double stdtrit(double df, double p) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double result, bound
+        int status = 10
+        char *argnames[3]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "df"
+
+    result, status, bound = cdft_which2(p, q, df)
+    return get_result("stdtrit", argnames, result, status, bound, 1)

--- a/scipy/special/_cdflib_wrappers.pxd
+++ b/scipy/special/_cdflib_wrappers.pxd
@@ -248,6 +248,22 @@ cdef inline double gdtria(double p, double shp, double x) noexcept nogil:
     return get_result("gdtria", argnames, result, status, bound, 1)
 
 
+cdef inline double gdtrib(double scl, double p, double x) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double result, bound
+        int status = 10
+        char *argnames[4]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "x"
+    argnames[3] = "scl"
+
+    result, status, bound = cdfgam_which3(p, q, x, scl)
+    return get_result("gdtrib", argnames, result, status, bound, 1)
+
+
 cdef inline double gdtrix(double scl, double shp, double p) noexcept nogil:
     cdef:
         double q = 1.0 - p

--- a/scipy/special/_cdflib_wrappers.pxd
+++ b/scipy/special/_cdflib_wrappers.pxd
@@ -2,7 +2,47 @@ from . cimport sf_error
 
 from libc.math cimport NAN
 
-from ._cdflib cimport cdfbet_which3
+from ._cdflib cimport (
+    cdfbet_which3,
+    cdfbet_which4,
+)
+
+
+cdef inline double get_result(
+        char *name,
+        char **argnames,
+        double result,
+        int status,
+        double bound,
+        int return_bound
+) noexcept nogil:
+    cdef char *arg
+    """Get result and perform error handling from cdflib output."""
+    if status < 0:
+        arg = argnames[-(status + 1)]
+        sf_error.error(name, sf_error.ARG,
+                       "Input parameter %s is out of range", arg)
+        return NAN
+    if status == 0:
+        return result
+    if status == 1:
+        sf_error.error(name, sf_error.OTHER,
+                       "Answer appears to be lower than lowest search bound (%g)", bound)
+        return bound if return_bound else NAN
+    if status == 2:
+        sf_error.error(name, sf_error.OTHER,
+                       "Answer appears to be higher than highest search bound (%g)", bound)
+        return bound if return_bound else NAN
+    if status == 3 or status == 4:
+        sf_error.error(name, sf_error.OTHER,
+                       "Two internal parameters that should sum to 1.0 do not.")
+        return NAN
+    if status == 10:
+        sf_error.error(name, sf_error.OTHER, "Computational error")
+        return NAN
+    sf_error.error(name, sf_error.OTHER, "Unknown error.")
+    return NAN
+    
 
 
 cdef inline double btdtria(double p, double b, double x) noexcept nogil:
@@ -11,30 +51,32 @@ cdef inline double btdtria(double p, double b, double x) noexcept nogil:
         double y = 1.0 - x
         double result, bound
         int status
-        char arg;
+        char *argnames[5]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "x"
+    argnames[3] = "y"
+    argnames[4] = "b"
 
     result, status, bound = cdfbet_which3(p, q, x, y, b)
-    if status < 0:
-        arg = b'p' if status == -1 else b'x' if status == -2 else b'b'
-        sf_error.error("btdtria", sf_error.ARG,
-                       "Input parameter %c is out of range", arg)
-        return NAN
-    if status == 0:
-        return result
-    if status == 1:
-        sf_error.error("btdtria", sf_error.OTHER,
-                       "Answer appears to be lower than lowest search bound (%g)", bound)
-        return bound
-    if status == 2:
-        sf_error.error("btdtria", sf_error.OTHER,
-                       "Answer appears to be higher than highest search bound (%g)", bound)
-        return bound
-    if status == 3 or status == 4:
-        sf_error.error("btdtria", sf_error.OTHER,
-                       "Two parameters that should sum to 1.0 do not.")
-        return NAN
-    if status == 10:
-        sf_error.error("btdtria", sf_error.OTHER, "Computational error")
-        return NAN
-    sf_error.error("btdtria", sf_error.OTHER, "Unknown error.")
-    return NAN
+    return get_result("btdtria", argnames, result, status, bound, 1)
+
+
+
+cdef inline double btdtrib(double p, double a, double x) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double y = 1.0 - x
+        double result, bound
+        int status
+        char *argnames[5]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "x"
+    argnames[3] = "y"
+    argnames[4] = "a"
+
+    result, status, bound = cdfbet_which4(p, q, x, y, a)
+    return get_result("btdtrib", argnames, result, status, bound, 1)

--- a/scipy/special/_cdflib_wrappers.pxd
+++ b/scipy/special/_cdflib_wrappers.pxd
@@ -5,6 +5,8 @@ from libc.math cimport NAN
 from ._cdflib cimport (
     cdfbet_which3,
     cdfbet_which4,
+    cdfbin_which2,
+    cdfbin_which3,
 )
 
 
@@ -80,3 +82,39 @@ cdef inline double btdtrib(double p, double a, double x) noexcept nogil:
 
     result, status, bound = cdfbet_which4(p, q, x, y, a)
     return get_result("btdtrib", argnames, result, status, bound, 1)
+
+
+cdef inline double bdtrik(double p, double xn, double pr) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double ompr = 1.0 - pr
+        double result, bound
+        int status
+        char *argnames[5]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "xn"
+    argnames[3] = "pr"
+    argnames[4] = "ompr"
+
+    result, status, bound = cdfbin_which2(p, q, xn, pr, ompr)
+    return get_result("btdtrik", argnames, result, status, bound, 1)
+
+
+cdef inline double bdtrin(double s, double p, double pr) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double ompr = 1.0 - pr
+        double result, bound
+        int status = 10
+        char *argnames[5]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "s"
+    argnames[3] = "pr"
+    argnames[4] = "ompr"
+
+    result, status, bound = cdfbin_which3(p, q, s, pr, ompr)
+    return get_result("btdtrin", argnames, result, status, bound, 1)

--- a/scipy/special/_cdflib_wrappers.pxd
+++ b/scipy/special/_cdflib_wrappers.pxd
@@ -7,6 +7,19 @@ from ._cdflib cimport (
     cdfbet_which4,
     cdfbin_which2,
     cdfbin_which3,
+    cdfchi_which3,
+    cdfchn_which1,
+    cdfchn_which2,
+    cdfchn_which3,
+    cdfchn_which4,
+    cdff_which4,
+    cdfgam_which2,
+    cdfgam_which3,
+    cdfgam_which4,
+    cdfnbn_which2,
+    cdfnbn_which3,
+    cdffnc_which1,
+    cdffnc_which2,
 )
 
 
@@ -118,3 +131,175 @@ cdef inline double bdtrin(double s, double p, double pr) noexcept nogil:
 
     result, status, bound = cdfbin_which3(p, q, s, pr, ompr)
     return get_result("btdtrin", argnames, result, status, bound, 1)
+
+
+cdef inline double chdtriv(double p, double x) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double result, bound
+        int status = 10
+        char *argnames[3]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "x"
+
+    result, status, bound = cdfchi_which3(p, q, x)
+    return get_result("chdtriv", argnames, result, status, bound, 1)
+
+
+cdef inline double chndtr(double x, double df, double nc) noexcept nogil:
+    cdef:
+        double result, _, bound
+        int status = 10
+        char *argnames[3]
+
+    argnames[0] = "x"
+    argnames[1] = "df"
+    argnames[2] = "nc"
+
+    result, _, status, bound = cdfchn_which1(x, df, nc)
+    return get_result("chndtr", argnames, result, status, bound, 1)
+
+
+cdef inline double chndtridf(double x, double p, double nc) noexcept nogil:
+    cdef:
+        double result, bound
+        int status = 10
+        char *argnames[3]
+
+    argnames[0] = "p"
+    argnames[1] = "x"
+    argnames[2] = "nc"
+
+    result, status, bound = cdfchn_which3(p, x, nc)
+    return get_result("chndtridf", argnames, result, status, bound, 1)
+
+
+cdef inline double chndtrinc(double x, double df, double p) noexcept nogil:
+    cdef:
+        double result, bound
+        int status = 10
+        char *argnames[3]
+
+    argnames[0] = "p"
+    argnames[1] = "x"
+    argnames[2] = "df"
+
+    result, status, bound = cdfchn_which4(p, x, df)
+    return get_result("chndtrinc", argnames, result, status, bound, 1)
+
+
+cdef inline double chndtrix(double p, double df, double nc) noexcept nogil:
+    cdef:
+        double result, bound
+        int status = 10
+        char *argnames[3]
+
+    argnames[0] = "p"
+    argnames[1] = "df"
+    argnames[2] = "nc"
+
+    result, status, bound = cdfchn_which2(p, df, nc)
+    return get_result("chndtrix", argnames, result, status, bound, 0)
+
+
+cdef inline double fdtridfd(double dfn, double p, double f) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double result, bound
+        int status = 10
+        char *argnames[4]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "f"
+    argnames[3] = "dfn"
+
+    result, status, bound = cdff_which4(p, q, f, dfn)
+    return get_result("fdtridfd", argnames, result, status, bound, 1)
+
+
+cdef inline double gdtria(double p, double shp, double x) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double result, bound
+        int status = 10
+        char *argnames[4]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "x"
+    argnames[3] = "shp"
+
+    result, status, bound = cdfgam_which4(p, q, x, shp)
+    return get_result("gdtria", argnames, result, status, bound, 1)
+
+
+cdef inline double gdtrix(double scl, double shp, double p) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double result, bound
+        int status = 10
+        char *argnames[4]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "shp"
+    argnames[3] = "scl"
+
+    result, status, bound = cdfgam_which2(p, q, shp, scl)
+    return get_result("gdtrix", argnames, result, status, bound, 1)
+
+
+cdef inline double nbdtrik(double p, double xn, double pr) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double ompr = 1.0 - pr
+        double result, bound
+        int status = 10
+        char *argnames[5]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "xn"
+    argnames[3] = "pr"
+    argnames[4] = "ompr"
+
+    result, status, bound = cdfnbn_which2(p, q, xn, pr, ompr)
+    return get_result("nbdtrik", argnames, result, status, bound, 1)
+
+
+cdef inline double nbdtrin(double s, double p, double pr) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double ompr = 1.0 - pr
+        double result, bound
+        int status = 10
+        char *argnames[5]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[2] = "s"
+    argnames[3] = "pr"
+    argnames[4] = "ompr"
+
+    result, status, bound = cdfnbn_which3(p, q, s, pr, ompr)
+    return get_result("nbdtrin", argnames, result, status, bound, 1)
+
+
+cdef inline double ncfdtri(double dfn, double dfd, double nc, double p) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double result, bound
+        int status = 10
+        char *argnames[5]
+
+    argnames[0] = "p"
+    argnames[1] = "q"
+    argnames[1] = "dfn"
+    argnames[2] = "dfd"
+    argnames[3] = "nc"
+
+    result, status, bound = cdffnc_which2(p, q, dfn, dfd, nc)
+    return get_result("ncfdtri", argnames, result, status, bound, 1)

--- a/scipy/special/_cdflib_wrappers.pxd
+++ b/scipy/special/_cdflib_wrappers.pxd
@@ -50,7 +50,7 @@ cdef inline double btdtria(double p, double b, double x) noexcept nogil:
         double q = 1.0 - p
         double y = 1.0 - x
         double result, bound
-        int status
+        int status = 10
         char *argnames[5]
 
     argnames[0] = "p"
@@ -69,7 +69,7 @@ cdef inline double btdtrib(double p, double a, double x) noexcept nogil:
         double q = 1.0 - p
         double y = 1.0 - x
         double result, bound
-        int status
+        int status = 10
         char *argnames[5]
 
     argnames[0] = "p"

--- a/scipy/special/_cdflib_wrappers.pxd
+++ b/scipy/special/_cdflib_wrappers.pxd
@@ -16,25 +16,25 @@ cdef inline double btdtria(double p, double b, double x) noexcept nogil:
     result, status, bound = cdfbet_which3(p, q, x, y, b)
     if status < 0:
         arg = b'p' if status == -1 else b'x' if status == -2 else b'b'
-        sf_error.error("btdria", sf_error.ARG,
+        sf_error.error("btdtria", sf_error.ARG,
                        "Input parameter %c is out of range", arg)
         return NAN
     if status == 0:
         return result
     if status == 1:
-        sf_error.error("btdria", sf_error.OTHER,
+        sf_error.error("btdtria", sf_error.OTHER,
                        "Answer appears to be lower than lowest search bound (%g)", bound)
         return bound
     if status == 2:
-        sf_error.error("btdria", sf_error.OTHER,
+        sf_error.error("btdtria", sf_error.OTHER,
                        "Answer appears to be higher than highest search bound (%g)", bound)
         return bound
     if status == 3 or status == 4:
-        sf_error.error("btdria", sf_error.OTHER,
+        sf_error.error("btdtria", sf_error.OTHER,
                        "Two parameters that should sum to 1.0 do not.")
         return NAN
     if status == 10:
-        sf_error.error("btdria", sf_error.OTHER, "Computational error")
+        sf_error.error("btdtria", sf_error.OTHER, "Computational error")
         return NAN
-    sf_error.error("btdria", sf_error.OTHER, "Unknown error.")
+    sf_error.error("btdtria", sf_error.OTHER, "Unknown error.")
     return NAN

--- a/scipy/special/_cdflib_wrappers.pxd
+++ b/scipy/special/_cdflib_wrappers.pxd
@@ -1,0 +1,40 @@
+from . cimport sf_error
+
+from libc.math cimport NAN
+
+from ._cdflib cimport cdfbet_which3
+
+
+cdef inline double btdtria(double p, double b, double x) noexcept nogil:
+    cdef:
+        double q = 1.0 - p
+        double y = 1.0 - x
+        double result, bound
+        int status
+        char arg;
+
+    result, status, bound = cdfbet_which3(p, q, x, y, b)
+    if status < 0:
+        arg = b'p' if status == -1 else b'x' if status == -2 else b'b'
+        sf_error.error("btdria", sf_error.ARG,
+                       "Input parameter %c is out of range", arg)
+        return NAN
+    if status == 0:
+        return result
+    if status == 1:
+        sf_error.error("btdria", sf_error.OTHER,
+                       "Answer appears to be lower than lowest search bound (%g)", bound)
+        return bound
+    if status == 2:
+        sf_error.error("btdria", sf_error.OTHER,
+                       "Answer appears to be higher than highest search bound (%g)", bound)
+        return bound
+    if status == 3 or status == 4:
+        sf_error.error("btdria", sf_error.OTHER,
+                       "Two parameters that should sum to 1.0 do not.")
+        return NAN
+    if status == 10:
+        sf_error.error("btdria", sf_error.OTHER, "Computational error")
+        return NAN
+    sf_error.error("btdria", sf_error.OTHER, "Unknown error.")
+    return NAN

--- a/scipy/special/_cdflib_wrappers.pxd
+++ b/scipy/special/_cdflib_wrappers.pxd
@@ -300,6 +300,21 @@ cdef inline double nbdtrin(double s, double p, double pr) noexcept nogil:
     return get_result("nbdtrin", argnames, result, status, bound, 1)
 
 
+cdef inline double ncfdtr(double dfn, double dfd, double nc, double f) noexcept nogil:
+    cdef:
+        double result, _, bound
+        int status = 10
+        char *argnames[4]
+
+    argnames[0] = "f"
+    argnames[1] = "dfn"
+    argnames[2] = "dfd"
+    argnames[3] = "nc"
+
+    result, _, status, bound = cdffnc_which1(f, dfn, dfd, nc)
+    return get_result("ncfdtr", argnames, result, status, bound, 0)
+
+
 cdef inline double ncfdtri(double dfn, double dfd, double nc, double p) noexcept nogil:
     cdef:
         double q = 1.0 - p

--- a/scipy/special/cdf_wrappers.h
+++ b/scipy/special/cdf_wrappers.h
@@ -57,5 +57,4 @@ extern double cdftnc2_wrap(double df, double nc, double p);
 extern double cdftnc3_wrap(double p, double nc, double t);
 extern double cdftnc4_wrap(double df, double p, double t);
 
-extern double tukeylambdacdf(double x, double lambda);
 #endif

--- a/scipy/special/cephes.h
+++ b/scipy/special/cephes.h
@@ -156,6 +156,8 @@ extern double lanczos_sum_expg_scaled(double x);
 
 extern double owens_t(double h, double a);
 
+extern double tukeylambdacdf(double x, double lambda);
+
 #ifdef __cplusplus
 }
 #endif

--- a/scipy/special/cephes.h
+++ b/scipy/special/cephes.h
@@ -156,6 +156,8 @@ extern double lanczos_sum_expg_scaled(double x);
 
 extern double owens_t(double h, double a);
 
+extern double tukeylambdacdf(double x, double lmbda);
+
 #ifdef __cplusplus
 }
 #endif

--- a/scipy/special/cephes.h
+++ b/scipy/special/cephes.h
@@ -156,8 +156,6 @@ extern double lanczos_sum_expg_scaled(double x);
 
 extern double owens_t(double h, double a);
 
-extern double tukeylambdacdf(double x, double lmbda);
-
 #ifdef __cplusplus
 }
 #endif

--- a/scipy/special/cephes.hh
+++ b/scipy/special/cephes.hh
@@ -128,6 +128,7 @@ namespace scipy {
 #undef kolmogc
 #undef kolmogci
 #undef owens_t
+#undef tukeylambdacdf
 	    }
 	}
     }

--- a/scipy/special/cephes/cephes_names.h
+++ b/scipy/special/cephes/cephes_names.h
@@ -110,5 +110,6 @@
 #define kolmogc cephes_kolmogc
 #define kolmogci cephes_kolmogci
 #define owens_t cephes_owens_t
+#define tukeylambdacdf cephes_tukeylambdacdf
 
 #endif

--- a/scipy/special/cephes/cephes_names.h
+++ b/scipy/special/cephes/cephes_names.h
@@ -110,6 +110,5 @@
 #define kolmogc cephes_kolmogc
 #define kolmogci cephes_kolmogci
 #define owens_t cephes_owens_t
-#define tukeylambdacdf cephes_tukeylambdacdf
 
 #endif

--- a/scipy/special/cephes/tukey.c
+++ b/scipy/special/cephes/tukey.c
@@ -8,8 +8,7 @@
  * Author:  Travis Oliphant 
  */
 
-#include <Python.h>
-#include <math.h>
+#include "mconf.h"
 
 #define SMALLVAL 1e-4
 #define EPS 1.0e-14

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -182,9 +182,19 @@
             "cdfbin2_wrap": "ddd->d"
         }
     },
+    "bdtrik_cython": {
+        "_cdflib_wrappers.pxd": {
+            "bdtrik": "ddd->d"
+        }
+    },
     "bdtrin": {
         "cdf_wrappers.h": {
             "cdfbin3_wrap": "ddd->d"
+        }
+    },
+    "bdtrin_cython": {
+        "_cdflib_wrappers.pxd": {
+            "bdtrin": "ddd->d"
         }
     },
     "bei": {
@@ -316,9 +326,19 @@
             "cdfchi3_wrap": "dd->d"
         }
     },
+    "chdtriv_cython": {
+        "_cdflib_wrappers.pxd": {
+            "chdtriv": "dd->d"
+        }
+    },
     "chndtr": {
         "cdf_wrappers.h": {
             "cdfchn1_wrap": "ddd->d"
+        }
+    },
+    "chndtr_cython": {
+        "_cdflib_wrappers.pxd": {
+            "chndtr": "ddd->d"
         }
     },
     "chndtridf": {
@@ -326,14 +346,29 @@
             "cdfchn3_wrap": "ddd->d"
         }
     },
+    "chndtridf_cython": {
+        "_cdflib_wrappers.pxd": {
+            "chndtridf": "ddd->d"
+        }
+    },
     "chndtrinc": {
         "cdf_wrappers.h": {
             "cdfchn4_wrap": "ddd->d"
         }
     },
+    "chndtrinc_cython": {
+        "_cdflib_wrappers.pxd": {
+            "chndtrinc": "ddd->d"
+        }
+    },
     "chndtrix": {
         "cdf_wrappers.h": {
             "cdfchn2_wrap": "ddd->d"
+        }
+    },
+    "chndtrix_cython": {
+        "_cdflib_wrappers.pxd": {
+            "chndtrix": "ddd->d"
         }
     },
     "cosdg": {
@@ -642,6 +677,11 @@
             "cdff4_wrap": "ddd->d"
         }
     },
+    "fdtridfd_cython": {
+        "_cdflib_wrappers.pxd": {
+            "fdtridfd": "ddd->d"
+        }
+    },
     "fresnel": {
         "cephes.h": {
             "fresnl": "d*dd->*i"
@@ -703,14 +743,24 @@
             "cdfgam4_wrap": "ddd->d"
         }
     },
+    "gdtria_cython": {
+        "_cdflib_wrappers.pxd": {
+            "gdtria": "ddd->d"
+        }
+    },
     "gdtrib": {
         "cdf_wrappers.h": {
             "cdfgam3_wrap": "ddd->d"
         }
     },
+    "gdtrib_cython": {
+        "_cdflib_wrappers.pxd": {
+            "gdtrib": "ddd->d"
+        }
+    },
     "gdtrix": {
-        "cdf_wrappers.h": {
-            "cdfgam2_wrap": "ddd->d"
+        "_cdflib_wrappers.pxd": {
+            "gdtrix": "ddd->d"
         }
     },
     "hankel1": {
@@ -1089,9 +1139,19 @@
             "cdfnbn2_wrap": "ddd->d"
         }
     },
+    "nbdtrik_cython": {
+        "_cdflib_wrappers.pxd": {
+            "nbdtrik": "ddd->d"
+        }
+    },
     "nbdtrin": {
         "cdf_wrappers.h": {
             "cdfnbn3_wrap": "ddd->d"
+        }
+    },
+    "nbdtrin_cython": {
+        "_cdflib_wrappers.pxd": {
+            "nbdtrin": "ddd->d"
         }
     },
     "ncfdtr": {
@@ -1099,9 +1159,19 @@
             "cdffnc1_wrap": "dddd->d"
         }
     },
+    "ncfdtr_cython": {
+        "_cdflib_wrappers.pxd": {
+            "ncfdtr": "dddd->d"
+        }
+    },
     "ncfdtri": {
         "cdf_wrappers.h": {
             "cdffnc2_wrap": "dddd->d"
+        }
+    },
+    "ncfdtri_cython": {
+        "_cdflib_wrappers.pxd": {
+            "ncfdtri": "dddd->d"
         }
     },
     "ncfdtridfd": {
@@ -1109,9 +1179,19 @@
             "cdffnc4_wrap": "dddd->d"
         }
     },
+    "ncfdtridfd_cython": {
+        "_cdflib_wrappers.pxd": {
+            "ncfdtridfd": "dddd->d"
+        }
+    },
     "ncfdtridfn": {
         "cdf_wrappers.h": {
             "cdffnc3_wrap": "dddd->d"
+        }
+    },
+    "ncfdtridfn_cython": {
+        "_cdflib_wrappers.pxd": {
+            "ncfdtridfn": "dddd->d"
         }
     },
     "ncfdtrinc": {
@@ -1119,9 +1199,19 @@
             "cdffnc5_wrap": "dddd->d"
         }
     },
+    "ncfdtrinc_cython": {
+        "_cdflib_wrappers.pxd": {
+            "ncfdtrinc": "dddd->d"
+        }
+    },
     "nctdtr": {
         "cdf_wrappers.h": {
             "cdftnc1_wrap": "ddd->d"
+        }
+    },
+    "nctdtr_cython": {
+        "_cdflib_wrappers.pxd": {
+            "nctdtr": "ddd->d"
         }
     },
     "nctdtridf": {
@@ -1134,9 +1224,19 @@
             "cdftnc4_wrap": "ddd->d"
         }
     },
+    "nctdtrinc_cython": {
+        "_cdflib_wrappers.pxd": {
+            "nctdtrinc": "ddd->d"
+        }
+    },
     "nctdtrit": {
         "cdf_wrappers.h": {
             "cdftnc2_wrap": "ddd->d"
+        }
+    },
+    "nctdtrit_cython": {
+        "_cdflib_wrappers.pxd": {
+            "nctdtrit": "ddd->d"
         }
     },
     "ndtr": {
@@ -1157,9 +1257,19 @@
             "cdfnor3_wrap": "ddd->d"
         }
     },
+    "nrdtrimn_cython": {
+        "_cdflib_wrappers.pxd": {
+            "nrdtrimn": "ddd->d"
+        }
+    },
     "nrdtrisd": {
         "cdf_wrappers.h": {
             "cdfnor4_wrap": "ddd->d"
+        }
+    },
+    "nrdtrisd_cython": {
+        "_cdflib_wrappers.pxd": {
+            "nrdtrisd": "ddd->d"
         }
     },
     "obl_ang1": {
@@ -1238,6 +1348,11 @@
     "pdtrik": {
         "cdf_wrappers.h": {
             "cdfpoi2_wrap": "dd->d"
+        }
+    },
+    "pdtrik_cython": {
+        "_cdflib_wrappers.pxd": {
+            "pdtrik": "dd->d"
         }
     },
     "poch": {
@@ -1402,14 +1517,29 @@
             "cdft1_wrap": "dd->d"
         }
     },
+    "stdtr_cython": {
+        "_cdflib_wrappers.pxd": {
+            "stdtr": "dd->d"
+        }
+    },
     "stdtridf": {
         "cdf_wrappers.h": {
             "cdft3_wrap": "dd->d"
         }
     },
+    "stdtridf_cython": {
+        "_cdflib_wrappers.pxd": {
+            "stdtridf": "dd->d"
+        }
+    },
     "stdtrit": {
         "cdf_wrappers.h": {
             "cdft2_wrap": "dd->d"
+        }
+    },
+    "stdtrit_cython": {
+        "_cdflib_wrappers.pxd": {
+            "stdtrit": "dd->d"
         }
     },
     "struve": {
@@ -1424,6 +1554,11 @@
     },
     "tklmbda": {
         "cdf_wrappers.h": {
+            "tukeylambdacdf": "dd->d"
+        }
+    },
+    "tklmbda_cephes": {
+        "cephes.h": {
             "tukeylambdacdf": "dd->d"
         }
     },

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -286,6 +286,11 @@
             "cdfbet4_wrap": "ddd->d"
         }
     },
+    "btdtrib_cython": {
+        "_cdflib_wrappers.pxd": {
+            "btdtrib": "ddd->d"
+        }
+    },
     "cbrt": {
         "cephes.h": {
             "cbrt": "d->d"

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -276,6 +276,11 @@
             "cdfbet3_wrap": "ddd->d"
         }
     },
+    "btdtria_cython": {
+        "_cdflib_wrappers.pxd": {
+            "btdtria": "ddd->d"
+        }
+    },
     "btdtrib": {
         "cdf_wrappers.h": {
             "cdfbet4_wrap": "ddd->d"

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -1553,7 +1553,7 @@
         }
     },
     "tklmbda": {
-        "cdf_wrappers.h": {
+        "cephes.h": {
             "tukeylambdacdf": "dd->d"
         }
     },

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -1557,11 +1557,6 @@
             "tukeylambdacdf": "dd->d"
         }
     },
-    "tklmbda_cephes": {
-        "cephes.h": {
-            "tukeylambdacdf": "dd->d"
-        }
-    },
     "wofz": {
         "_faddeeva.h++": {
             "faddeeva_w": "D->D"

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -5,6 +5,7 @@ _ufuncs_pxi_pxd_sources = [
   fs.copyfile('_agm.pxd'),
   fs.copyfile('_boxcox.pxd'),
   fs.copyfile('_cdflib.pxd'),
+  fs.copyfile('_cdflib_wrappers.pxd'),
   fs.copyfile('_cephes.pxd'),
   fs.copyfile('_complexstuff.pxd'),
   fs.copyfile('_convex_analysis.pxd'),


### PR DESCRIPTION
Thanks @ilayn for getting the meson build set up. I was working on it in parallel trying to make `_cdflib.pyx` a static library instead of an extension module and didn't have it working; an extension module is fine. Here's a PR adding a wrapper for `btdtria`,  I've just added a ufunc `btdtria_cython` alongside `btdtria` for now so we can test them together. I put the wrapper in a separate file `_cdflib_wrappers.pxd`. 

I noticed a slight discrepancy when the answer is higher than the highest search bound.

```
In [6]: sc.btdtria_cython(0.5, 0.7, 1)
1e+100 2 inf
<ipython-input-6-bba4ba34f83c>:1: SpecialFunctionWarning: scipy.special/btdria: (other error) Answer appears to be higher than highest search bound (inf)
Out[6]: inf
```

In [10]: sc.btdtria(0.5, 0.7, 1)
<ipython-input-10-245b194ab9a9>:1: SpecialFunctionWarning: scipy.special/btdtria: (other error) Answer appears to be higher than highest search bound (1e+100)
  sc.btdtria(0.5, 0.7, 1)
Out[10]: 1e+100

I think it's fine to return `inf` when the answer exceeds the highest search bound, and I could just rewrite the error message, but I think the right thing to do is have cdfbet_whichx and others have the same behavior as the original when bounds are exceeded, and we could then adjust the result in the wrapper.